### PR TITLE
feat(JFrogCliV2): allow persisting and reusing JFrog CLI config across steps

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -144,6 +144,7 @@ const minCustomCliVersion = '2.10.0';
 const minSupportedStdinSecretCliVersion = '2.36.0';
 const minSupportedServerIdEnvCliVersion = '2.37.0';
 const minSupportedOidcCliVersion = '2.75.0';
+const minSupportedPackageAliasCliVersion = '2.93.0';
 const pluginVersion = '2.14.2';
 const buildAgent = 'jfrog-azure-devops-extension';
 
@@ -229,6 +230,7 @@ module.exports = {
     configureDefaultDistributionServer: configureDefaultDistributionServer,
     configureDefaultXrayServer: configureDefaultXrayServer,
     minCustomCliVersion: minCustomCliVersion,
+    minSupportedPackageAliasCliVersion: minSupportedPackageAliasCliVersion,
     defaultJfrogCliVersion: defaultJfrogCliVersion,
     fallbackCliVersion: fallbackCliVersion,
     pipelineRequestedCliVersionEnv: pipelineRequestedCliVersionEnv,
@@ -512,7 +514,11 @@ function forwardProxyToEnv() {
                 const converted = [];
                 for (const h of hosts) {
                     if (/[*+?[\]()^${}|\\][^.]/.test(h) || h.includes('*')) {
-                        tl.warning('Skipping Agent.ProxyBypassList entry "' + h + '": regex patterns with wildcards or special characters are not supported for NO_PROXY conversion. Use a plain hostname in your .proxybypass file instead.');
+                        tl.warning(
+                            'Skipping Agent.ProxyBypassList entry "' +
+                                h +
+                                '": regex patterns with wildcards or special characters are not supported for NO_PROXY conversion. Use a plain hostname in your .proxybypass file instead.',
+                        );
                         continue;
                     }
                     converted.push(h.replace(/\\\./g, '.'));

--- a/tasks/JFrogCliV2/jfrogCliRun.js
+++ b/tasks/JFrogCliV2/jfrogCliRun.js
@@ -1,6 +1,7 @@
 const tl = require('azure-pipelines-task-lib/task');
 const utils = require('@jfrog/tasks-utils/utils.js');
 const fs = require('fs');
+const path = require('path');
 
 let serverId;
 RunJfrogCliCommand(RunTaskCbk);
@@ -46,8 +47,27 @@ async function RunTaskCbk(cliPath) {
     process.env.JFROG_CLI_BUILD_NAME = tl.getVariable('Build.DefinitionName');
     process.env.JFROG_CLI_BUILD_NUMBER = tl.getVariable('Build.BuildNumber');
 
-    serverId = utils.assembleUniqueServerId('jfrog_cli_cmd');
-    await utils.configureDefaultJfrogServer(serverId, cliPath, requiredWorkDir);
+    let configurationName = tl.getInput('configurationName', false);
+    if (configurationName) {
+        // Reuse an existing JFrog CLI configuration instead of creating a new one.
+        serverId = configurationName;
+    } else {
+        if (!tl.getInput('jfrogPlatformConnection', false)) {
+            tl.setResult(tl.TaskResult.Failed, "Either 'JFrog Platform service connection' or 'Configuration Name' must be provided.");
+            return;
+        }
+        serverId = utils.assembleUniqueServerId('jfrog_cli_cmd');
+        await utils.configureDefaultJfrogServer(serverId, cliPath, requiredWorkDir);
+    }
+    tl.setVariable('JFROG_CLI_CONFIG_NAME', serverId, false, true);
+
+    if (tl.getBoolInput('registerInPath')) {
+        tl.prependPath(path.dirname(cliPath));
+    }
+
+    if (tl.getBoolInput('enablePackageAlias')) {
+        setUpPackageAlias(cliPath, requiredWorkDir);
+    }
 
     let cliCommandsList = tl.getInput('command', true).split('\n');
     try {
@@ -58,7 +78,9 @@ async function RunTaskCbk(cliPath) {
                     tl.TaskResult.Failed,
                     "Unexpected JFrog CLI command prefix. Expecting the command to start with 'jf '. The command received is: " + cliCommand,
                 );
-                utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
+                if (!tl.getBoolInput('keepConfig')) {
+                    utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
+                }
                 return;
             }
             // Remove 'jf' and space from the beginning of the command string, so we can use the CLI's path
@@ -77,7 +99,33 @@ async function RunTaskCbk(cliPath) {
     } catch (executionException) {
         tl.setResult(tl.TaskResult.Failed, executionException);
     } finally {
-        utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
+        if (!tl.getBoolInput('keepConfig')) {
+            utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
+        }
     }
     tl.setResult(tl.TaskResult.Succeeded, 'Command Succeeded.', cliPath);
+}
+
+/**
+ * Installs JFrog CLI's package-alias ('Ghost Frog') shims and registers them on PATH,
+ * so native build tool invocations for the rest of the pipeline job route through 'jf'.
+ */
+function setUpPackageAlias(cliPath, requiredWorkDir) {
+    let cliVersion = tl.getVariable(utils.taskSelectedCliVersionEnv);
+    if (utils.compareVersions(cliVersion, utils.minSupportedPackageAliasCliVersion) < 0) {
+        console.warn(
+            `Package Alias is not supported by JFrog CLI ${cliVersion}. Minimum required version is ${utils.minSupportedPackageAliasCliVersion}. Skipping.`,
+        );
+        return;
+    }
+    let packageAliasCommand = utils.cliJoin(cliPath, 'package-alias', 'install');
+    let packageAliasTools = tl.getInput('packageAliasTools', false);
+    if (packageAliasTools) {
+        packageAliasCommand = utils.cliJoin(packageAliasCommand, '--packages=' + utils.quote(packageAliasTools));
+    }
+    utils.executeCliCommand(packageAliasCommand, requiredWorkDir);
+
+    tl.prependPath(path.join(utils.getJfrogFolderPath(), 'package-alias', 'bin'));
+    process.env.JFROG_CLI_GHOST_FROG = 'true';
+    tl.setVariable('JFROG_CLI_GHOST_FROG', 'true');
 }

--- a/tasks/JFrogCliV2/task.json
+++ b/tasks/JFrogCliV2/task.json
@@ -6,10 +6,7 @@
     "author": "JFrog",
     "category": "Tool",
     "helpMarkDown": "[More Information](https://github.com/jfrog/jfrog-azure-devops-extension#Executing-JFrog-CLI-Commands)",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "version": {
         "Major": "1",
         "Minor": "14",
@@ -24,8 +21,8 @@
             "type": "connectedService:jfrogPlatformService",
             "label": "JFrog Platform service connection",
             "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "JFrog Platform service connection to use in the command."
+            "required": false,
+            "helpMarkDown": "JFrog Platform service connection to use in the command. Required unless 'Configuration Name' is provided to reuse an existing JFrog CLI configuration."
         },
         {
             "name": "useCustomVersion",
@@ -63,6 +60,47 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "The working directory where the command will run. When empty, the value of '$(System.DefaultWorkingDirectory)' is used."
+        },
+        {
+            "name": "configurationName",
+            "type": "string",
+            "label": "Configuration Name",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Reuse an existing JFrog CLI configuration by name instead of creating a new one from 'JFrog Platform service connection'. The named configuration must already exist in the JFrog CLI's config store (for example, created by a previous run of this task with 'Keep Configuration' enabled)."
+        },
+        {
+            "name": "registerInPath",
+            "type": "boolean",
+            "label": "Add JFrog CLI to PATH",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Add the JFrog CLI executable's directory to the agent's PATH, so subsequent steps in the pipeline job can call 'jf' directly."
+        },
+        {
+            "name": "keepConfig",
+            "type": "boolean",
+            "label": "Keep Configuration",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Skip removing the JFrog CLI configuration when this task completes, so it can be reused by later steps via 'Configuration Name'. Use the 'JFROG_CLI_CONFIG_NAME' variable set by this task to reference it, and run a teardown task with 'Configuration Name' set and 'Keep Configuration' disabled to remove it at the end of the pipeline."
+        },
+        {
+            "name": "enablePackageAlias",
+            "type": "boolean",
+            "label": "Enable Package Alias (Ghost Frog)",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Install JFrog CLI's package-alias shims (requires JFrog CLI 2.93.0 or later), which transparently route native build tool commands (npm, mvn, gradle, dotnet, nuget, pip, go, docker, etc.) through 'jf' for the rest of the pipeline job. Requires 'Add JFrog CLI to PATH' to be enabled."
+        },
+        {
+            "name": "packageAliasTools",
+            "type": "string",
+            "label": "Package Alias Tools",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "enablePackageAlias = true",
+            "helpMarkDown": "Comma-separated list of tools to enable package aliasing for (e.g. 'npm,dotnet'). Leave empty to enable all supported tools."
         }
     ],
     "execution": {


### PR DESCRIPTION
## Reasons

I created this PR as an implementation of my feature request #636

It is a combination of a few features, if you prefer seperate PR's I can split it up.

But together they give the option of doing a big migration to JFrog a lot easier, by just adding the task in the front of the pipeline, and in the end to gather and push the buildinfo and keep the rest of the pipeline in place.

## Summary
- Adds opt-in inputs to `JFrogCliV2` so downstream pipeline steps (e.g. `dotnet restore`) can reuse the CLI config this task creates, instead of every step needing its own JFrog Platform service connection.
- `registerInPath` (default `false`) — adds `jf`'s directory to the agent's PATH for later steps.
- `keepConfig` (default `false`) — skips the cleanup step so the config survives after this task finishes.
- `configurationName` (optional) — reuse an existing named config instead of creating a new one; `jfrogPlatformConnection` becomes optional when this is set (the task fails clearly if neither is provided).
- `enablePackageAlias` / `packageAliasTools` (default `false`) — installs JFrog CLI's `package-alias` ("Ghost Frog") shims (requires CLI ≥ 2.93.0; warns and skips on older versions) so native build tool calls route through `jf` for the rest of the job.
- The resolved config name is exposed via the `JFROG_CLI_CONFIG_NAME` pipeline variable, intended for a paired "teardown" task at the end of the pipeline (`configurationName=$(JFROG_CLI_CONFIG_NAME)`, `keepConfig=false`) to delete the persisted config.
- Added `minSupportedPackageAliasCliVersion` (`2.93.0`) constant to `jfrog-tasks-utils/utils.js`, following the existing `minSupported*CliVersion` pattern.

All new behavior is off by default, so existing pipelines using `JFrogCliV2` are unaffected.

## Test plan
- [x] `node --check` on `tasks/JFrogCliV2/jfrogCliRun.js` and `jfrog-tasks-utils/utils.js`
- [x] Validated `tasks/JFrogCliV2/task.json` parses as valid JSON
- [x] Formatted all changed files with the project's Prettier config (`.prettierrc`)
- [ ] Manual pipeline verification:
  - [ ] Default run (all new inputs at default) behaves identically to before
  - [ ] Setup/teardown pair: setup with `configurationName` empty, `keepConfig=true`, `registerInPath=true`; teardown with `configurationName=$(JFROG_CLI_CONFIG_NAME)`, `keepConfig=false`
  - [ ] `enablePackageAlias=true` on a CLI version below `2.93.0` logs a warning and the task still succeeds