### PR TITLE
feat(JFrogCliV2): add option to register JFrog CLI on agent PATH

### DIFF
--- a/tasks/JFrogCliV2/jfrogCliRun.js
+++ b/tasks/JFrogCliV2/jfrogCliRun.js
@@ -1,6 +1,7 @@
 const tl = require('azure-pipelines-task-lib/task');
 const utils = require('@jfrog/tasks-utils/utils.js');
 const fs = require('fs');
+const path = require('path');
 
 let serverId;
 RunJfrogCliCommand(RunTaskCbk);
@@ -48,6 +49,10 @@ async function RunTaskCbk(cliPath) {
 
     serverId = utils.assembleUniqueServerId('jfrog_cli_cmd');
     await utils.configureDefaultJfrogServer(serverId, cliPath, requiredWorkDir);
+
+    if (tl.getBoolInput('registerInPath')) {
+        tl.prependPath(path.dirname(cliPath));
+    }
 
     let cliCommandsList = tl.getInput('command', true).split('\n');
     try {

--- a/tasks/JFrogCliV2/task.json
+++ b/tasks/JFrogCliV2/task.json
@@ -63,6 +63,14 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "The working directory where the command will run. When empty, the value of '$(System.DefaultWorkingDirectory)' is used."
+        },
+        {
+            "name": "registerInPath",
+            "type": "boolean",
+            "label": "Add JFrog CLI to PATH",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Add the JFrog CLI executable's directory to the agent's PATH, so subsequent steps in the pipeline job can call 'jf' directly."
         }
     ],
     "execution": {

--- a/tests/resources/jfrogCliV2RegisterInPath/registerInPath.js
+++ b/tests/resources/jfrogCliV2RegisterInPath/registerInPath.js
@@ -1,0 +1,9 @@
+const testUtils = require('../../testUtils');
+
+let inputs = {
+    jfrogPlatformConnection: 'mock-service',
+    registerInPath: true,
+    command: 'jf rt ping',
+};
+
+testUtils.runPlatformTask(testUtils.genericCli, {}, inputs);

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -589,6 +589,20 @@ describe('JFrog Artifactory Extension Tests', (): void => {
         );
     });
 
+    describe('JFrog CLI V2 Tests', (): void => {
+        runSyncTest(
+            'Adds the JFrog CLI directory to PATH when registerInPath is enabled',
+            async (): Promise<void> => {
+                const runner: adoMockTest.MockTestRunner = await mockTaskCapture('jfrogCliV2RegisterInPath', 'registerInPath');
+                assert.ok(
+                    /##vso\[task\.prependpath\].+/.test(runner.stdout),
+                    'Expected a "prependpath" logging command in task output.\n' + runner.stdout,
+                );
+            },
+            TestUtils.isSkipTest('generic'),
+        );
+    });
+
     describe('Tools Installer Tests', (): void => {
         runSyncTest(
             'Download CLI',
@@ -1420,6 +1434,18 @@ function runAsyncTest(description: string, testFunc: (done: mocha.Done) => void,
  * @param shouldFail (Boolean, Optional) - True if the task supposed to fail
  */
 async function mockTask(testDir: string, taskName: string, shouldFail?: boolean): Promise<void> {
+    await mockTaskCapture(testDir, taskName, shouldFail);
+}
+
+/**
+ * Mock a task from resources directory, returning the runner so its stdout/stderr can be inspected
+ * (e.g. to assert on a "##vso[...]" logging command, or to pull a value out of the task's output).
+ *
+ * @param testDir (String) - The test directory in resources
+ * @param taskName (String) - The '.js' file
+ * @param shouldFail (Boolean, Optional) - True if the task supposed to fail
+ */
+async function mockTaskCapture(testDir: string, taskName: string, shouldFail?: boolean): Promise<adoMockTest.MockTestRunner> {
     const taskPath: string = join(__dirname, 'resources', testDir, taskName + '.js');
     // task.json dummy passed to the mock runner to avoid the 'Unable to find task.json, ...' warnings.
     const taskJsonDummy: string = join(__dirname, 'resources', 'task.json');
@@ -1427,6 +1453,7 @@ async function mockTask(testDir: string, taskName: string, shouldFail?: boolean)
     await mockRunner.runAsync();
     tasksOutput += mockRunner.stderr + '\n' + mockRunner.stdout;
     assert.ok(shouldFail ? mockRunner.failed : mockRunner.succeeded, '\nFailure in: ' + taskPath + '.\n' + tasksOutput); // Check the test results
+    return mockRunner;
 }
 
 /**


### PR DESCRIPTION
## Summary

Split out of #637 per reviewer feedback (multiple independent changes bundled into one PR). This is one of 3 independent PRs split out of #637 - #651 (persist/reuse config) and #652 (Package Alias) are the other two. All three are independent and can be reviewed/merged in any order.

Adds an opt-in `registerInPath` input to `JFrogCliV2`. When enabled, the JFrog CLI executable's directory is prepended to the agent's PATH, so later steps in the same pipeline job can call `jf` directly without a separate install/config step.

This is off by default, so existing pipelines using `JFrogCliV2` are unaffected.

## Test plan
- `node --check tasks/JFrogCliV2/jfrogCliRun.js`
- Validated `tasks/JFrogCliV2/task.json` parses as valid JSON
- Added an integration test (`tests/resources/jfrogCliV2RegisterInPath/registerInPath.js` + a new `describe` block in `tests/tests.ts`) asserting the task emits a `##vso[task.prependpath]` logging command when `registerInPath` is enabled, following the existing `tests/resources/<taskDir>/<scenario>.js` + `mockTask`/`runSyncTest` pattern used by sibling tasks.

## Note on CI
The `Tests` workflow is a `pull_request_target` workflow gated behind a `safe to test` label, and for fork PRs GitHub always runs the **base branch's** copy of that workflow file (a built-in security control against fork PRs granting themselves elevated permissions) - so a maintainer needs to add the label for the integration test above to actually execute in CI. This can't be changed from the PR branch itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)