### PR TITLE
feat(JFrogCliV2): allow persisting and reusing JFrog CLI config across steps

### DIFF
--- a/tasks/JFrogCliV2/jfrogCliRun.js
+++ b/tasks/JFrogCliV2/jfrogCliRun.js
@@ -46,8 +46,19 @@ async function RunTaskCbk(cliPath) {
     process.env.JFROG_CLI_BUILD_NAME = tl.getVariable('Build.DefinitionName');
     process.env.JFROG_CLI_BUILD_NUMBER = tl.getVariable('Build.BuildNumber');
 
-    serverId = utils.assembleUniqueServerId('jfrog_cli_cmd');
-    await utils.configureDefaultJfrogServer(serverId, cliPath, requiredWorkDir);
+    let configurationName = tl.getInput('configurationName', false);
+    if (configurationName) {
+        // Reuse an existing JFrog CLI configuration instead of creating a new one.
+        serverId = configurationName;
+    } else {
+        if (!tl.getInput('jfrogPlatformConnection', false)) {
+            tl.setResult(tl.TaskResult.Failed, "Either 'JFrog Platform service connection' or 'Configuration Name' must be provided.");
+            return;
+        }
+        serverId = utils.assembleUniqueServerId('jfrog_cli_cmd');
+        await utils.configureDefaultJfrogServer(serverId, cliPath, requiredWorkDir);
+    }
+    tl.setVariable('JFROG_CLI_CONFIG_NAME', serverId, false, true);
 
     let cliCommandsList = tl.getInput('command', true).split('\n');
     try {
@@ -58,7 +69,9 @@ async function RunTaskCbk(cliPath) {
                     tl.TaskResult.Failed,
                     "Unexpected JFrog CLI command prefix. Expecting the command to start with 'jf '. The command received is: " + cliCommand,
                 );
-                utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
+                if (!tl.getBoolInput('keepConfig')) {
+                    utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
+                }
                 return;
             }
             // Remove 'jf' and space from the beginning of the command string, so we can use the CLI's path
@@ -77,7 +90,9 @@ async function RunTaskCbk(cliPath) {
     } catch (executionException) {
         tl.setResult(tl.TaskResult.Failed, executionException);
     } finally {
-        utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
+        if (!tl.getBoolInput('keepConfig')) {
+            utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
+        }
     }
     tl.setResult(tl.TaskResult.Succeeded, 'Command Succeeded.', cliPath);
 }

--- a/tasks/JFrogCliV2/task.json
+++ b/tasks/JFrogCliV2/task.json
@@ -24,8 +24,8 @@
             "type": "connectedService:jfrogPlatformService",
             "label": "JFrog Platform service connection",
             "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "JFrog Platform service connection to use in the command."
+            "required": false,
+            "helpMarkDown": "JFrog Platform service connection to use in the command. Required unless 'Configuration Name' is provided to reuse an existing JFrog CLI configuration."
         },
         {
             "name": "useCustomVersion",
@@ -63,6 +63,22 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "The working directory where the command will run. When empty, the value of '$(System.DefaultWorkingDirectory)' is used."
+        },
+        {
+            "name": "configurationName",
+            "type": "string",
+            "label": "Configuration Name",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Reuse an existing JFrog CLI configuration by name instead of creating a new one from 'JFrog Platform service connection'. The named configuration must already exist in the JFrog CLI's config store (for example, created by a previous run of this task with 'Keep Configuration' enabled)."
+        },
+        {
+            "name": "keepConfig",
+            "type": "boolean",
+            "label": "Keep Configuration",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Skip removing the JFrog CLI configuration when this task completes, so it can be reused by later steps via 'Configuration Name'. Use the 'JFROG_CLI_CONFIG_NAME' variable set by this task to reference it, and run a teardown task with 'Configuration Name' set and 'Keep Configuration' disabled to remove it at the end of the pipeline."
         }
     ],
     "execution": {

--- a/tests/resources/jfrogCliV2PersistConfig/keepConfigSetup.js
+++ b/tests/resources/jfrogCliV2PersistConfig/keepConfigSetup.js
@@ -1,0 +1,11 @@
+const testUtils = require('../../testUtils');
+
+// Creates a new JFrog CLI configuration and keeps it around (does not clean up on completion),
+// so a later task invocation can reuse it via 'configurationName'.
+let inputs = {
+    jfrogPlatformConnection: 'mock-service',
+    keepConfig: true,
+    command: 'jf rt ping',
+};
+
+testUtils.runPlatformTask(testUtils.genericCli, {}, inputs);

--- a/tests/resources/jfrogCliV2PersistConfig/missingConnectionAndConfigName.js
+++ b/tests/resources/jfrogCliV2PersistConfig/missingConnectionAndConfigName.js
@@ -1,0 +1,8 @@
+const testUtils = require('../../testUtils');
+
+// Neither 'jfrogPlatformConnection' nor 'configurationName' is provided - the task must fail clearly.
+let inputs = {
+    command: 'jf rt ping',
+};
+
+testUtils.runPlatformTask(testUtils.genericCli, {}, inputs);

--- a/tests/resources/jfrogCliV2PersistConfig/reuseConfigurationName.js
+++ b/tests/resources/jfrogCliV2PersistConfig/reuseConfigurationName.js
@@ -1,0 +1,10 @@
+const testUtils = require('../../testUtils');
+
+// Reuses the configuration created (and kept) by 'keepConfigSetup.js', identified by name,
+// without providing a service connection - and tears it down (keepConfig defaults to false).
+let inputs = {
+    configurationName: process.env.ADO_TEST_PERSISTED_CONFIG_NAME,
+    command: 'jf rt ping',
+};
+
+testUtils.runPlatformTask(testUtils.genericCli, {}, inputs);

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -589,6 +589,46 @@ describe('JFrog Artifactory Extension Tests', (): void => {
         );
     });
 
+    describe('JFrog CLI V2 Persist Config Tests', (): void => {
+        const testDir: string = 'jfrogCliV2PersistConfig';
+
+        runSyncTest(
+            'Fails clearly when neither JFrog Platform connection nor Configuration Name is provided',
+            async (): Promise<void> => {
+                await mockTask(testDir, 'missingConnectionAndConfigName', true);
+            },
+            TestUtils.isSkipTest('generic'),
+        );
+
+        runSyncTest(
+            'Keeps and reuses the JFrog CLI configuration across two task invocations',
+            async (): Promise<void> => {
+                // Run the setup task directly (instead of via mockTask) so its stdout can be inspected
+                // for the JFROG_CLI_CONFIG_NAME value emitted via "##vso[task.setvariable ...]".
+                const taskJsonDummy: string = join(__dirname, 'resources', 'task.json');
+                const setupPath: string = join(__dirname, 'resources', testDir, 'keepConfigSetup.js');
+                const setupRunner: adoMockTest.MockTestRunner = new adoMockTest.MockTestRunner(setupPath, taskJsonDummy);
+                await setupRunner.runAsync();
+                tasksOutput += setupRunner.stderr + '\n' + setupRunner.stdout;
+                assert.ok(setupRunner.succeeded, '\nFailure in: ' + setupPath + '.\n' + tasksOutput);
+
+                const configNameMatch: RegExpMatchArray | null = setupRunner.stdout.match(
+                    /##vso\[task\.setvariable variable=JFROG_CLI_CONFIG_NAME;[^\]]*\](\S+)/,
+                );
+                assert.ok(configNameMatch, 'Expected JFROG_CLI_CONFIG_NAME to be set in task output.\n' + setupRunner.stdout);
+                process.env.ADO_TEST_PERSISTED_CONFIG_NAME = (configNameMatch as RegExpMatchArray)[1];
+                try {
+                    // Second invocation reuses the configuration by name, without a service connection,
+                    // and tears it down (keepConfig defaults to false).
+                    await mockTask(testDir, 'reuseConfigurationName');
+                } finally {
+                    delete process.env.ADO_TEST_PERSISTED_CONFIG_NAME;
+                }
+            },
+            TestUtils.isSkipTest('generic'),
+        );
+    });
+
     describe('Tools Installer Tests', (): void => {
         runSyncTest(
             'Download CLI',


### PR DESCRIPTION
## Reasons

Split out of #637 (implementation of feature request #636) per reviewer feedback - the original PR bundled a few independent changes into one. This PR contains only the config persistence/reuse scenario. It is independent of the other two split-out PRs (#650 register-in-PATH, and a Package Alias PR) and can be reviewed/merged on its own, in any order.

## Summary

Adds opt-in inputs so downstream pipeline steps (e.g. `dotnet restore`) can reuse the CLI config this task creates, instead of every step needing its own JFrog Platform service connection:

- `configurationName` (optional) - reuse an existing named config instead of creating a new one; `jfrogPlatformConnection` becomes optional when this is set (the task fails clearly if neither is provided).
- `keepConfig` (default `false`) - skips the cleanup step so the config survives after this task finishes.
- The resolved config name is exposed via the `JFROG_CLI_CONFIG_NAME` pipeline variable, intended for a paired "teardown" task at the end of the pipeline (`configurationName=$(JFROG_CLI_CONFIG_NAME)`, `keepConfig=false`) to delete the persisted config.

All new behavior is off by default, so existing pipelines using `JFrogCliV2` are unaffected.

## Test plan
- `node --check tasks/JFrogCliV2/jfrogCliRun.js`
- Validated `tasks/JFrogCliV2/task.json` parses as valid JSON
- Added integration tests under `tests/resources/jfrogCliV2PersistConfig/` (+ a new `describe` block in `tests/tests.ts`), following the existing `tests/resources/<taskDir>/<scenario>.js` + `mockTask`/`runSyncTest` pattern:
  - Fails clearly when neither `jfrogPlatformConnection` nor `configurationName` is provided.
  - Keeps a configuration via `keepConfig`, then reuses it by name via `configurationName` in a second task invocation (with no service connection), verifying the persist/reuse round-trip.

## Note on CI
The `Tests` workflow is a `pull_request_target` workflow gated behind a `safe to test` label, and for fork PRs GitHub always runs the **base branch's** copy of that workflow file (a built-in security control against fork PRs granting themselves elevated permissions) - so a maintainer needs to add the label for the integration tests above to actually execute in CI. This can't be changed from the PR branch itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)