### PR TITLE
feat(JFrogCliV2): add Package Alias (Ghost Frog) support

### DIFF
--- a/jfrog-tasks-utils/utils.js
+++ b/jfrog-tasks-utils/utils.js
@@ -144,6 +144,7 @@ const minCustomCliVersion = '2.10.0';
 const minSupportedStdinSecretCliVersion = '2.36.0';
 const minSupportedServerIdEnvCliVersion = '2.37.0';
 const minSupportedOidcCliVersion = '2.75.0';
+const minSupportedPackageAliasCliVersion = '2.93.0';
 const pluginVersion = '2.14.2';
 const buildAgent = 'jfrog-azure-devops-extension';
 
@@ -233,6 +234,7 @@ module.exports = {
     configureDefaultDistributionServer: configureDefaultDistributionServer,
     configureDefaultXrayServer: configureDefaultXrayServer,
     minCustomCliVersion: minCustomCliVersion,
+    minSupportedPackageAliasCliVersion: minSupportedPackageAliasCliVersion,
     defaultJfrogCliVersion: defaultJfrogCliVersion,
     fallbackCliVersion: fallbackCliVersion,
     pipelineRequestedCliVersionEnv: pipelineRequestedCliVersionEnv,

--- a/tasks/JFrogCliV2/jfrogCliRun.js
+++ b/tasks/JFrogCliV2/jfrogCliRun.js
@@ -1,6 +1,7 @@
 const tl = require('azure-pipelines-task-lib/task');
 const utils = require('@jfrog/tasks-utils/utils.js');
 const fs = require('fs');
+const path = require('path');
 
 let serverId;
 RunJfrogCliCommand(RunTaskCbk);
@@ -49,6 +50,10 @@ async function RunTaskCbk(cliPath) {
     serverId = utils.assembleUniqueServerId('jfrog_cli_cmd');
     await utils.configureDefaultJfrogServer(serverId, cliPath, requiredWorkDir);
 
+    if (tl.getBoolInput('enablePackageAlias')) {
+        setUpPackageAlias(cliPath, requiredWorkDir);
+    }
+
     let cliCommandsList = tl.getInput('command', true).split('\n');
     try {
         for (let cliCommand of cliCommandsList) {
@@ -80,4 +85,28 @@ async function RunTaskCbk(cliPath) {
         utils.taskDefaultCleanup(cliPath, requiredWorkDir, [serverId]);
     }
     tl.setResult(tl.TaskResult.Succeeded, 'Command Succeeded.', cliPath);
+}
+
+/**
+ * Installs JFrog CLI's package-alias ('Ghost Frog') shims and registers them on PATH,
+ * so native build tool invocations for the rest of the pipeline job route through 'jf'.
+ */
+function setUpPackageAlias(cliPath, requiredWorkDir) {
+    let cliVersion = tl.getVariable(utils.taskSelectedCliVersionEnv);
+    if (utils.compareVersions(cliVersion, utils.minSupportedPackageAliasCliVersion) < 0) {
+        console.warn(
+            `Package Alias is not supported by JFrog CLI ${cliVersion}. Minimum required version is ${utils.minSupportedPackageAliasCliVersion}. Skipping.`,
+        );
+        return;
+    }
+    let packageAliasCommand = utils.cliJoin(cliPath, 'package-alias', 'install');
+    let packageAliasTools = tl.getInput('packageAliasTools', false);
+    if (packageAliasTools) {
+        packageAliasCommand = utils.cliJoin(packageAliasCommand, '--packages=' + utils.quote(packageAliasTools));
+    }
+    utils.executeCliCommand(packageAliasCommand, requiredWorkDir);
+
+    tl.prependPath(path.join(utils.getJfrogFolderPath(), 'package-alias', 'bin'));
+    process.env.JFROG_CLI_GHOST_FROG = 'true';
+    tl.setVariable('JFROG_CLI_GHOST_FROG', 'true');
 }

--- a/tasks/JFrogCliV2/task.json
+++ b/tasks/JFrogCliV2/task.json
@@ -63,6 +63,23 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "The working directory where the command will run. When empty, the value of '$(System.DefaultWorkingDirectory)' is used."
+        },
+        {
+            "name": "enablePackageAlias",
+            "type": "boolean",
+            "label": "Enable Package Alias (Ghost Frog)",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Install JFrog CLI's package-alias shims (requires JFrog CLI 2.93.0 or later), which transparently route native build tool commands (npm, mvn, gradle, dotnet, nuget, pip, go, docker, etc.) through 'jf' for the rest of the pipeline job."
+        },
+        {
+            "name": "packageAliasTools",
+            "type": "string",
+            "label": "Package Alias Tools",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "enablePackageAlias = true",
+            "helpMarkDown": "Comma-separated list of tools to enable package aliasing for (e.g. 'npm,dotnet'). Leave empty to enable all supported tools."
         }
     ],
     "execution": {

--- a/tests/resources/jfrogCliV2PackageAlias/enablePackageAlias.js
+++ b/tests/resources/jfrogCliV2PackageAlias/enablePackageAlias.js
@@ -1,0 +1,9 @@
+const testUtils = require('../../testUtils');
+
+let inputs = {
+    jfrogPlatformConnection: 'mock-service',
+    enablePackageAlias: true,
+    command: 'jf rt ping',
+};
+
+testUtils.runPlatformTask(testUtils.genericCli, {}, inputs);

--- a/tests/resources/jfrogCliV2PackageAlias/packageAliasUnsupportedVersion.js
+++ b/tests/resources/jfrogCliV2PackageAlias/packageAliasUnsupportedVersion.js
@@ -1,0 +1,13 @@
+const testUtils = require('../../testUtils');
+
+// Forces a CLI version older than the Package Alias minimum (2.93.0) - the task must
+// still succeed, only skipping Package Alias setup with a warning.
+let inputs = {
+    jfrogPlatformConnection: 'mock-service',
+    useCustomVersion: true,
+    cliVersion: '2.92.0',
+    enablePackageAlias: true,
+    command: 'jf rt ping',
+};
+
+testUtils.runPlatformTask(testUtils.genericCli, {}, inputs);

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -589,6 +589,48 @@ describe('JFrog Artifactory Extension Tests', (): void => {
         );
     });
 
+    describe('JFrog CLI V2 Package Alias Tests', (): void => {
+        const testDir: string = 'jfrogCliV2PackageAlias';
+        const taskJsonDummy: string = join(__dirname, 'resources', 'task.json');
+
+        runSyncTest(
+            'Installs Package Alias shims and sets JFROG_CLI_GHOST_FROG when enabled',
+            async (): Promise<void> => {
+                const taskPath: string = join(__dirname, 'resources', testDir, 'enablePackageAlias.js');
+                const runner: adoMockTest.MockTestRunner = new adoMockTest.MockTestRunner(taskPath, taskJsonDummy);
+                await runner.runAsync();
+                tasksOutput += runner.stderr + '\n' + runner.stdout;
+                assert.ok(runner.succeeded, '\nFailure in: ' + taskPath + '.\n' + tasksOutput);
+                assert.ok(runner.stdout.includes('package-alias install'), 'Expected a "package-alias install" command in task output.\n' + runner.stdout);
+                assert.ok(
+                    /##vso\[task\.setvariable variable=JFROG_CLI_GHOST_FROG;[^\]]*\]true/.test(runner.stdout),
+                    'Expected JFROG_CLI_GHOST_FROG to be set to true in task output.\n' + runner.stdout,
+                );
+            },
+            TestUtils.isSkipTest('generic'),
+        );
+
+        runSyncTest(
+            'Skips Package Alias with a warning (but still succeeds) on an unsupported CLI version',
+            async (): Promise<void> => {
+                const taskPath: string = join(__dirname, 'resources', testDir, 'packageAliasUnsupportedVersion.js');
+                const runner: adoMockTest.MockTestRunner = new adoMockTest.MockTestRunner(taskPath, taskJsonDummy);
+                await runner.runAsync();
+                tasksOutput += runner.stderr + '\n' + runner.stdout;
+                assert.ok(runner.succeeded, '\nFailure in: ' + taskPath + '.\n' + tasksOutput);
+                assert.ok(
+                    !runner.stdout.includes('package-alias install'),
+                    'Did not expect a "package-alias install" command in task output.\n' + runner.stdout,
+                );
+                assert.ok(
+                    (runner.stderr + runner.stdout).includes('Package Alias is not supported by JFrog CLI'),
+                    'Expected an unsupported-version warning in task output.\n' + runner.stderr + '\n' + runner.stdout,
+                );
+            },
+            TestUtils.isSkipTest('generic'),
+        );
+    });
+
     describe('Tools Installer Tests', (): void => {
         runSyncTest(
             'Download CLI',


### PR DESCRIPTION
## Reasons

Split out of #637 per reviewer feedback - the original PR bundled a few independent changes into one. This PR contains only the Package Alias scenario. It is independent of the other two split-out PRs (#650 register-in-PATH, #651 persist/reuse config) and can be reviewed/merged on its own, in any order.

## Summary

Adds an opt-in `enablePackageAlias` input (default `false`) to `JFrogCliV2` that installs JFrog CLI's `package-alias` ("Ghost Frog") shims (requires CLI ≥ 2.93.0; warns and skips on older versions instead of failing) so native build tool calls (npm, mvn, gradle, dotnet, nuget, pip, go, docker, etc.) route through `jf` for the rest of the pipeline job. `packageAliasTools` (optional) scopes which tools get aliased.

Added `minSupportedPackageAliasCliVersion` (`2.93.0`) constant to `jfrog-tasks-utils/utils.js`, following the existing `minSupported*CliVersion` pattern.

All new behavior is off by default, so existing pipelines using `JFrogCliV2` are unaffected.

## Test plan
- `node --check tasks/JFrogCliV2/jfrogCliRun.js` and `jfrog-tasks-utils/utils.js`
- Validated `tasks/JFrogCliV2/task.json` parses as valid JSON
- Added integration tests under `tests/resources/jfrogCliV2PackageAlias/` (+ a new `describe` block in `tests/tests.ts`), following the existing `tests/resources/<taskDir>/<scenario>.js` + `mockTask`/`runSyncTest` pattern:
  - `enablePackageAlias=true` on a supported CLI version runs `package-alias install` and sets `JFROG_CLI_GHOST_FROG`.
  - `enablePackageAlias=true` on a CLI version below `2.93.0` logs a warning, skips Package Alias setup, and the task still succeeds.

## Note on CI
The `Tests` workflow is a `pull_request_target` workflow gated behind a `safe to test` label, and for fork PRs GitHub always runs the **base branch's** copy of that workflow file (a built-in security control against fork PRs granting themselves elevated permissions) - so a maintainer needs to add the label for the integration tests above to actually execute in CI. This can't be changed from the PR branch itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)