### PR TITLE
Add GitHub Actions release workflow (JFrog Pipelines EOL migration)

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release script for jfrog-azure-devops-extension.
+# Extracted from .github/workflows/release.yml so it can be run either from
+# GitHub Actions or directly on a developer's machine.
+#
+# Expected environment variables:
+#   NEXT_VERSION         - version to release, e.g. 2.1.0
+#   IL_AUTOMATION_TOKEN  - GitHub token with push access to jfrog/jfrog-azure-devops-extension
+#   ARTIFACTORY_URL      - JFrog Artifactory URL
+#   ARTIFACTORY_USER     - JFrog Artifactory user
+#   ARTIFACTORY_APIKEY   - JFrog Artifactory API key/password
+#   AZURE_DEVOPS_TOKEN   - Azure DevOps Marketplace publish token
+#
+# To run locally: export the variables above, then run this script from the
+# root of a checkout of the v2 branch with the JFrog CLI (`jf`) already
+# installed and on PATH.
+
+# Always clean up the JFrog CLI config, even if an earlier command fails
+# (mirrors the "Cleanup JFrog CLI config" step's `if: always()` behavior).
+cleanup() {
+  jf c rm --quiet
+}
+trap cleanup EXIT
+
+git config user.name "jfrog-ecosystem-integration"
+git config user.email "eco-system@jfrog.com"
+git remote set-url origin https://${IL_AUTOMATION_TOKEN}@github.com/jfrog/jfrog-azure-devops-extension.git
+git fetch origin dev
+
+jf c rm --quiet
+jf c add internal --url=${ARTIFACTORY_URL} --user=${ARTIFACTORY_USER} --password=${ARTIFACTORY_APIKEY}
+
+git merge origin/dev
+
+npm i --unsafe-perm --prefix=buildScripts
+node buildScripts/bump-version.js -v "${NEXT_VERSION}"
+git commit -am "[jfrog-release] Release version ${NEXT_VERSION}"
+git tag "${NEXT_VERSION}"
+
+npm i --unsafe-perm
+jf audit --fail=false
+npm run create
+
+find . -iname "JFrog.jfrog-azure-devops-extension-${NEXT_VERSION}.vsix" -size +15M | grep .
+
+jf rt u "JFrog.jfrog-azure-devops-extension-${NEXT_VERSION}.vsix" ecosys-jfrog-azure-devops-extension/
+jf rt bag && jf rt bce
+jf rt bp
+
+npx tfx extension publish -t ${AZURE_DEVOPS_TOKEN}
+
+git push origin v2
+git push origin --tags
+
+git checkout dev
+git merge origin/v2
+git push origin dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,57 +30,11 @@ jobs:
       - name: Setup JFrog CLI
         uses: jfrog/setup-jfrog-cli@v4
 
-      - name: Configure git
-        run: |
-          git config user.name "jfrog-ecosystem-integration"
-          git config user.email "eco-system@jfrog.com"
-          git remote set-url origin https://${{ secrets.IL_AUTOMATION_TOKEN }}@github.com/jfrog/jfrog-azure-devops-extension.git
-          git fetch origin dev
-
-      - name: Configure JFrog CLI
-        run: |
-          jf c rm --quiet
-          jf c add internal --url=${{ secrets.ARTIFACTORY_URL }} --user=${{ secrets.ARTIFACTORY_USER }} --password=${{ secrets.ARTIFACTORY_APIKEY }}
-
-      - name: Merge latest dev
-        run: git merge origin/dev
-
-      - name: Bump version
-        run: |
-          npm i --unsafe-perm --prefix=buildScripts
-          node buildScripts/bump-version.js -v "${NEXT_VERSION}"
-          git commit -am "[jfrog-release] Release version ${NEXT_VERSION}"
-          git tag "${NEXT_VERSION}"
-
-      - name: Install, audit and build extension
-        run: |
-          npm i --unsafe-perm
-          jf audit --fail=false
-          npm run create
-
-      - name: Verify vsix size
-        run: find . -iname "JFrog.jfrog-azure-devops-extension-${NEXT_VERSION}.vsix" -size +15M | grep .
-
-      - name: Upload artifact and publish build info
-        run: |
-          jf rt u "JFrog.jfrog-azure-devops-extension-${NEXT_VERSION}.vsix" ecosys-jfrog-azure-devops-extension/
-          jf rt bag && jf rt bce
-          jf rt bp
-
-      - name: Publish to VS Marketplace
-        run: npx tfx extension publish -t ${{ secrets.AZURE_DEVOPS_TOKEN }}
-
-      - name: Push release branch
-        run: |
-          git push origin v2
-          git push origin --tags
-
-      - name: Merge back to dev
-        run: |
-          git checkout dev
-          git merge origin/v2
-          git push origin dev
-
-      - name: Cleanup JFrog CLI config
-        if: always()
-        run: jf c rm --quiet
+      - name: Run release script
+        env:
+          IL_AUTOMATION_TOKEN: ${{ secrets.IL_AUTOMATION_TOKEN }}
+          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
+          AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+        run: .github/scripts/release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+# Ported from .jfrog-pipelines/pipelines.release.yml (JFrog Pipelines is EOL)
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: "Version to release (e.g. 2.1.0)"
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_VERSION: ${{ github.event.inputs.next_version }}
+      JFROG_CLI_BUILD_NAME: ecosystem-azure-devops-extension-release
+      JFROG_CLI_BUILD_NUMBER: ${{ github.run_number }}
+      JFROG_CLI_BUILD_PROJECT: ecosys
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: v2
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "16"
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+
+      - name: Configure git
+        run: |
+          git config user.name "jfrog-ecosystem-integration"
+          git config user.email "eco-system@jfrog.com"
+          git remote set-url origin https://${{ secrets.IL_AUTOMATION_TOKEN }}@github.com/jfrog/jfrog-azure-devops-extension.git
+          git fetch origin dev
+
+      - name: Configure JFrog CLI
+        run: |
+          jf c rm --quiet
+          jf c add internal --url=${{ secrets.ARTIFACTORY_URL }} --user=${{ secrets.ARTIFACTORY_USER }} --password=${{ secrets.ARTIFACTORY_APIKEY }}
+
+      - name: Merge latest dev
+        run: git merge origin/dev
+
+      - name: Bump version
+        run: |
+          npm i --unsafe-perm --prefix=buildScripts
+          node buildScripts/bump-version.js -v "${NEXT_VERSION}"
+          git commit -am "[jfrog-release] Release version ${NEXT_VERSION}"
+          git tag "${NEXT_VERSION}"
+
+      - name: Install, audit and build extension
+        run: |
+          npm i --unsafe-perm
+          jf audit --fail=false
+          npm run create
+
+      - name: Verify vsix size
+        run: find . -iname "JFrog.jfrog-azure-devops-extension-${NEXT_VERSION}.vsix" -size +15M | grep .
+
+      - name: Upload artifact and publish build info
+        run: |
+          jf rt u "JFrog.jfrog-azure-devops-extension-${NEXT_VERSION}.vsix" ecosys-jfrog-azure-devops-extension/
+          jf rt bag && jf rt bce
+          jf rt bp
+
+      - name: Publish to VS Marketplace
+        run: npx tfx extension publish -t ${{ secrets.AZURE_DEVOPS_TOKEN }}
+
+      - name: Push release branch
+        run: |
+          git push origin v2
+          git push origin --tags
+
+      - name: Merge back to dev
+        run: |
+          git checkout dev
+          git merge origin/v2
+          git push origin dev
+
+      - name: Cleanup JFrog CLI config
+        if: always()
+        run: jf c rm --quiet


### PR DESCRIPTION
Ports `release_azure_devops_extension` from `.jfrog-pipelines/pipelines.release.yml` to a `workflow_dispatch` GitHub Actions workflow, as part of migrating off JFrog Pipelines (EOL).

**Behavior change from the original:** CLI install switched from `curl -fL https://install-cli.jfrog.io | sh` to the official `jfrog/setup-jfrog-cli@v4` action. Everything else — merging `dev` into `v2`, version bump, build, the >15M .vsix size check, Artifactory upload, VS Marketplace publish via `tfx`, and merging back to `dev` — mirrors the original pipeline step-for-step.

**Secrets required before this can run** (repo Settings → Secrets and variables → Actions):
- `IL_AUTOMATION_TOKEN` — GitHub token with push access to `jfrog/jfrog-azure-devops-extension`
- `ARTIFACTORY_URL`, `ARTIFACTORY_USER`, `ARTIFACTORY_APIKEY` — from the `ecosys_entplus_deployer` integration
- `AZURE_DEVOPS_TOKEN` — from the `azure_devops` integration (doubles as VS Marketplace publish token)

Not run yet — needs the secrets above added first.