### PR TITLE
Add GitHub Actions staging workflow (JFrog Pipelines EOL migration)

### DIFF
--- a/.github/scripts/staging.sh
+++ b/.github/scripts/staging.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Staging script for jfrog-azure-devops-extension.
+# Extracted from .github/workflows/staging.yml so it can be run either from
+# GitHub Actions or directly on a developer's machine.
+#
+# Expected environment variables:
+#   ADO_ARTIFACTORY_DEVELOPER - Artifactory developer identifier used for the staging publish
+#   ADO_ARTIFACTORY_API_KEY   - Azure DevOps Marketplace / Artifactory API key used to publish
+#
+# To run locally: export the variables above, then run this script from the
+# root of a checkout of the dev branch with Node.js already installed.
+
+npm run publish-private

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           ADO_ARTIFACTORY_DEVELOPER: ecosystem-staging
           ADO_ARTIFACTORY_API_KEY: ${{ secrets.AZURE_DEVOPS_TOKEN }}
-        run: npm run publish-private
+        run: .github/scripts/staging.sh

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,28 @@
+# Ported from .jfrog-pipelines/pipelines.staging.yml (JFrog Pipelines is EOL)
+name: Staging
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Publish extension to staging
+        env:
+          ADO_ARTIFACTORY_DEVELOPER: ecosystem-staging
+          ADO_ARTIFACTORY_API_KEY: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+        run: npm run publish-private


### PR DESCRIPTION
## Summary

Part of the JFrog Pipelines EOL migration for this repo. This adds a GitHub Actions workflow (`.github/workflows/staging.yml`) that ports the `create_azure_devops_extension_staging` pipeline from `.jfrog-pipelines/pipelines.staging.yml`.

- Triggers on push to `dev` (matching the existing GitRepo resource's commit-triggered behavior) and on `workflow_dispatch`.
- Checks out `dev`, sets up Node 20 (as declared in the JFrog Pipelines runtime config), and runs `npm run publish-private` to publish the extension to the Artifactory staging feed, matching the original pipeline step exactly.
- This complements the already-open release workflow PR (`add-release-github-workflow`), which added `.github/workflows/release.yml`.

## Required secret

- `AZURE_DEVOPS_TOKEN` — reuses the same secret name already required by the release workflow PR. Sourced from the `azure_devops` integration token in the old pipeline (`ADO_ARTIFACTORY_API_KEY`).

Not run yet — needs secrets added first.
